### PR TITLE
Fix unnecessary mutable access to pixel buffer image

### DIFF
--- a/src/pixel_buffer.rs
+++ b/src/pixel_buffer.rs
@@ -316,7 +316,7 @@ fn resize(
     >,
     mut images: ResMut<Assets<Image>>,
 ) {
-    for (image, pb) in pixel_buffer.iter() {
+    for (image_handle, pb) in pixel_buffer.iter() {
         let PixelBuffer { size, .. } = pb;
 
         if size.size.x == 0 || size.size.y == 0 || size.pixel_size.x == 0 || size.pixel_size.y == 0
@@ -325,8 +325,11 @@ fn resize(
             return;
         }
 
-        let image = images.get_mut(image).expect("pixel buffer image");
+        let image = images.get(image_handle).expect("pixel buffer image");
+
         if size.size != image.size() {
+            let image = images.get_mut(image_handle).expect("pixel buffer image");
+
             info!("Resizing image to: {:?}", size);
             image.resize(Extent3d {
                 width: size.size.x,


### PR DESCRIPTION
Hi! Fix for #11.
Getting mutable access to the image may be unnecessary, since the following `if` statement can evaluate to `false` (and we end up not modifying image).
https://github.com/Zheoni/bevy_pixel_buffer/blob/44a6d921ee09734e80ce6dfc552f07f973f8c7f9/src/pixel_buffer.rs#L328-L329
But getting mutable access to the image will send the `AssetEvent::Modified` event anyway, so the compute shader will invalidate the image for the current frame and prepare it only for drawing in the next frame, but in the next frame everything will repeat again.
https://github.com/Zheoni/bevy_pixel_buffer/blob/44a6d921ee09734e80ce6dfc552f07f973f8c7f9/src/compute_shader.rs#L267-L286